### PR TITLE
add READMEs to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ from its latest revision to the current Sequelize schema.
 atlas migrate diff --env sequelize 
 ````
 
+### Typescript
+for typescript support, see the [ts-atlas-provider-sequelize](https://github.com/ariga/atlas-provider-sequelize/tree/master/ts) README.
+
 ### Supported Databases
 
 The provider supports the following databases:
@@ -134,6 +137,7 @@ The provider supports the following databases:
 * PostgreSQL
 * SQLite
 * Microsoft SQL Server
+
 ### Issues
 
 Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # atlas-provider-sequelize
-Load [sequelize](https://sequelize.org/) models into an [Atlas](https://atlasgo.io) project.
+Load [Sequelize](https://sequelize.org/) models into an [Atlas](https://atlasgo.io) project.
+
+### Use-cases
+1. **Declarative migrations** - use a Terraform-like `atlas schema apply --env sequelize` to apply your Sequelize schema to the database.
+2. **Automatic migration planning** - use `atlas migrate diff --env sequelize` to automatically plan a migration from  
+  the current database version to the Sequelize schema.
 
 ### Installation
 
@@ -9,19 +14,20 @@ curl -sSf https://atlasgo.sh | sh
 ```
 See [atlasgo.io](https://atlasgo.io/getting-started#installation) for more installation options.
 
-### Usage
-
-Make sure your dependencies are installed:
+Install the provider by running:
 ```bash
-npm i 
+npm i @ariga/atlas-provider-sequelize
 ```
 
-Install the provider
+Make sure all your Node dependencies are installed by running:
 ```bash
-npm i @ariga/ts-atlas-provider-sequelize
-# for TypeScript:
-# npm i @ariga/ts-atlas-provider-sequelize
+npm i
 ```
+
+#### Standalone 
+
+If all of your Sequelize models exist in a single Node module, 
+you can use the provider directly to load your Sequelize schema into Atlas.
 
 In your project directory, create a new file named `atlas.hcl` with the following contents:
 
@@ -29,7 +35,7 @@ In your project directory, create a new file named `atlas.hcl` with the followin
 data "external_schema" "sequelize" {
   program = [
     "npx",
-    "@ariga/atlas-provider-sequelize", // or @ariga/ts-atlas-provider-sequelize for TypeScript
+    "@ariga/atlas-provider-sequelize",
     "load",
     "--path", "./path/to/models",
     "--dialect", "mysql", // mariadb | postgres | sqlite | mssql
@@ -50,6 +56,76 @@ env "sequelize" {
 }
 ```
 
+#### As JS Script 
+
+If you want to use the provider as JS script, you can use the provider as follows:
+
+Create a new file named `load.js` with the following contents:
+
+```js
+#!/usr/bin/env node
+
+// require sequelize models you want to load
+const user = require("./models/user");
+const task = require("./models/task");
+const loadModels = require("@ariga/atlas-provider-sequelize");
+
+console.log(loadModels("mysql", user, task));
+```
+
+Next, in your project directory, create a new file named `atlas.hcl` with the following contents:
+
+```hcl
+data "external_schema" "sequelize" {
+    program = [
+        "node",
+        "load.js",
+        "mysql"
+    ]
+}
+
+env "sequelize" {
+    src = data.external_schema.sequelize.url
+    dev = "docker://mysql/8/dev"
+    migration {
+        dir = "file://migrations"
+    }
+    format {
+        migrate {
+            diff = "{{ sql . \"  \" }}"
+        }
+    }
+}
+```
+
+### Usage
+
+Once you have the provider installed, you can use it to apply your Sequelize schema to the database:
+
+#### Apply
+
+You can use the `atlas schema apply` command to plan and apply a migration of your database to
+your current Sequelize schema. This works by inspecting the target database and comparing it to the
+Sequelize schema and creating a migration plan. Atlas will prompt you to confirm the migration plan
+before applying it to the database.
+
+```bash
+atlas schema apply --env sequelize -u "mysql://root:password@localhost:3306/mydb"
+```
+Where the `-u` flag accepts the [URL](https://atlasgo.io/concepts/url) to the
+target database.
+
+#### Diff
+
+Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) 
+workflow, where each change to the database is versioned and recorded in a migration file. You can use the
+`atlas migrate diff` command to automatically generate a migration file that will migrate the database
+from its latest revision to the current Sequelize schema.
+
+```bash
+atlas migrate diff --env sequelize 
+````
+
 ### Supported Databases
 
 The provider supports the following databases:
@@ -58,3 +134,10 @@ The provider supports the following databases:
 * PostgreSQL
 * SQLite
 * Microsoft SQL Server
+### Issues
+
+Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.
+
+### License
+
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/js/README.md
+++ b/js/README.md
@@ -1,32 +1,38 @@
 # atlas-provider-sequelize
+
 Load [Sequelize](https://sequelize.org/) models into an [Atlas](https://atlasgo.io) project.
 
 ### Use-cases
+
 1. **Declarative migrations** - use a Terraform-like `atlas schema apply --env sequelize` to apply your Sequelize schema to the database.
 2. **Automatic migration planning** - use `atlas migrate diff --env sequelize` to automatically plan a migration from  
-  the current database version to the Sequelize schema.
+   the current database version to the Sequelize schema.
 
 ### Installation
 
 Install Atlas from macOS or Linux by running:
+
 ```bash
 curl -sSf https://atlasgo.sh | sh
 ```
+
 See [atlasgo.io](https://atlasgo.io/getting-started#installation) for more installation options.
 
 Install the provider by running:
+
 ```bash
 npm i @ariga/atlas-provider-sequelize
 ```
 
 Make sure all your Node dependencies are installed by running:
+
 ```bash
 npm i
 ```
 
-#### Standalone 
+#### Standalone
 
-If all of your Sequelize models exist in a single Node module, 
+If all of your Sequelize models exist in a single Node module,
 you can use the provider directly to load your Sequelize schema into Atlas.
 
 In your project directory, create a new file named `atlas.hcl` with the following contents:
@@ -56,7 +62,7 @@ env "sequelize" {
 }
 ```
 
-#### As JS Script 
+#### As JS Script
 
 If you want to use the provider as JS script, you can use the provider as follows:
 
@@ -112,28 +118,31 @@ before applying it to the database.
 ```bash
 atlas schema apply --env sequelize -u "mysql://root:password@localhost:3306/mydb"
 ```
+
 Where the `-u` flag accepts the [URL](https://atlasgo.io/concepts/url) to the
 target database.
 
 #### Diff
 
-Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) 
+Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations)
 workflow, where each change to the database is versioned and recorded in a migration file. You can use the
 `atlas migrate diff` command to automatically generate a migration file that will migrate the database
 from its latest revision to the current Sequelize schema.
 
 ```bash
-atlas migrate diff --env sequelize 
-````
+atlas migrate diff --env sequelize
+```
 
 ### Supported Databases
 
 The provider supports the following databases:
-* MySQL
-* MariaDB
-* PostgreSQL
-* SQLite
-* Microsoft SQL Server
+
+- MySQL
+- MariaDB
+- PostgreSQL
+- SQLite
+- Microsoft SQL Server
+
 ### Issues
 
 Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,143 @@
+# atlas-provider-sequelize
+Load [Sequelize](https://sequelize.org/) models into an [Atlas](https://atlasgo.io) project.
+
+### Use-cases
+1. **Declarative migrations** - use a Terraform-like `atlas schema apply --env sequelize` to apply your Sequelize schema to the database.
+2. **Automatic migration planning** - use `atlas migrate diff --env sequelize` to automatically plan a migration from  
+  the current database version to the Sequelize schema.
+
+### Installation
+
+Install Atlas from macOS or Linux by running:
+```bash
+curl -sSf https://atlasgo.sh | sh
+```
+See [atlasgo.io](https://atlasgo.io/getting-started#installation) for more installation options.
+
+Install the provider by running:
+```bash
+npm i @ariga/atlas-provider-sequelize
+```
+
+Make sure all your Node dependencies are installed by running:
+```bash
+npm i
+```
+
+#### Standalone 
+
+If all of your Sequelize models exist in a single Node module, 
+you can use the provider directly to load your Sequelize schema into Atlas.
+
+In your project directory, create a new file named `atlas.hcl` with the following contents:
+
+```hcl
+data "external_schema" "sequelize" {
+  program = [
+    "npx",
+    "@ariga/atlas-provider-sequelize",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "mysql", // mariadb | postgres | sqlite | mssql
+  ]
+}
+
+env "sequelize" {
+  src = data.external_schema.sequelize.url
+  dev = "docker://mysql/8/dev"
+  migration {
+    dir = "file://migrations"
+  }
+  format {
+    migrate {
+      diff = "{{ sql . \"  \" }}"
+    }
+  }
+}
+```
+
+#### As JS Script 
+
+If you want to use the provider as JS script, you can use the provider as follows:
+
+Create a new file named `load.js` with the following contents:
+
+```js
+#!/usr/bin/env node
+
+// require sequelize models you want to load
+const user = require("./models/user");
+const task = require("./models/task");
+const loadModels = require("@ariga/atlas-provider-sequelize");
+
+console.log(loadModels("mysql", user, task));
+```
+
+Next, in your project directory, create a new file named `atlas.hcl` with the following contents:
+
+```hcl
+data "external_schema" "sequelize" {
+    program = [
+        "node",
+        "load.js",
+        "mysql"
+    ]
+}
+
+env "sequelize" {
+    src = data.external_schema.sequelize.url
+    dev = "docker://mysql/8/dev"
+    migration {
+        dir = "file://migrations"
+    }
+    format {
+        migrate {
+            diff = "{{ sql . \"  \" }}"
+        }
+    }
+}
+```
+
+### Usage
+
+Once you have the provider installed, you can use it to apply your Sequelize schema to the database:
+
+#### Apply
+
+You can use the `atlas schema apply` command to plan and apply a migration of your database to
+your current Sequelize schema. This works by inspecting the target database and comparing it to the
+Sequelize schema and creating a migration plan. Atlas will prompt you to confirm the migration plan
+before applying it to the database.
+
+```bash
+atlas schema apply --env sequelize -u "mysql://root:password@localhost:3306/mydb"
+```
+Where the `-u` flag accepts the [URL](https://atlasgo.io/concepts/url) to the
+target database.
+
+#### Diff
+
+Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) 
+workflow, where each change to the database is versioned and recorded in a migration file. You can use the
+`atlas migrate diff` command to automatically generate a migration file that will migrate the database
+from its latest revision to the current Sequelize schema.
+
+```bash
+atlas migrate diff --env sequelize 
+````
+
+### Supported Databases
+
+The provider supports the following databases:
+* MySQL
+* MariaDB
+* PostgreSQL
+* SQLite
+* Microsoft SQL Server
+### Issues
+
+Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.
+
+### License
+
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ariga/atlas-provider-sequelize",
   "version": "0.0.1",
-  "description": "",
+  "description": "Load Sequelize models into an Atlas project.",
+  "homepage": "https://github.com/ariga/atlas-provider-sequelize",
   "bin": "src/index.js",
   "keywords": [],
   "author": "",

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,32 +1,38 @@
 # ts-atlas-provider-sequelize
-Load [Sequelize-TypeScript](https://github.com/sequelize/sequelize-typescript)  models into an [Atlas](https://atlasgo.io) project.
+
+Load [Sequelize-TypeScript](https://github.com/sequelize/sequelize-typescript) models into an [Atlas](https://atlasgo.io) project.
 
 ### Use-cases
+
 1. **Declarative migrations** - use a Terraform-like `atlas schema apply --env sequelize` to apply your Sequelize schema to the database.
 2. **Automatic migration planning** - use `atlas migrate diff --env sequelize` to automatically plan a migration from  
-  the current database version to the Sequelize schema.
+   the current database version to the Sequelize schema.
 
 ### Installation
 
 Install Atlas from macOS or Linux by running:
+
 ```bash
 curl -sSf https://atlasgo.sh | sh
 ```
+
 See [atlasgo.io](https://atlasgo.io/getting-started#installation) for more installation options.
 
 Install the provider by running:
+
 ```bash
 npm i @ariga/ts-atlas-provider-sequelize
 ```
 
 Make sure all your Node dependencies are installed by running:
+
 ```bash
 npm i
 ```
 
-#### Standalone 
+#### Standalone
 
-If all of your Sequelize models exist in a single Node module, 
+If all of your Sequelize models exist in a single Node module,
 you can use the provider directly to load your Sequelize schema into Atlas.
 
 In your project directory, create a new file named `atlas.hcl` with the following contents:
@@ -56,7 +62,7 @@ env "sequelize" {
 }
 ```
 
-#### As TS Script 
+#### As TS Script
 
 If you want to use the provider as TS script, you can use the provider as follows:
 
@@ -113,28 +119,31 @@ before applying it to the database.
 ```bash
 atlas schema apply --env sequelize -u "mysql://root:password@localhost:3306/mydb"
 ```
+
 Where the `-u` flag accepts the [URL](https://atlasgo.io/concepts/url) to the
 target database.
 
 #### Diff
 
-Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) 
+Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations)
 workflow, where each change to the database is versioned and recorded in a migration file. You can use the
 `atlas migrate diff` command to automatically generate a migration file that will migrate the database
 from its latest revision to the current Sequelize schema.
 
 ```bash
-atlas migrate diff --env sequelize 
-````
+atlas migrate diff --env sequelize
+```
 
 ### Supported Databases
 
 The provider supports the following databases:
-* MySQL
-* MariaDB
-* PostgreSQL
-* SQLite
-* Microsoft SQL Server
+
+- MySQL
+- MariaDB
+- PostgreSQL
+- SQLite
+- Microsoft SQL Server
+
 ### Issues
 
 Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,0 +1,144 @@
+# ts-atlas-provider-sequelize
+Load [Sequelize-TypeScript](https://github.com/sequelize/sequelize-typescript)  models into an [Atlas](https://atlasgo.io) project.
+
+### Use-cases
+1. **Declarative migrations** - use a Terraform-like `atlas schema apply --env sequelize` to apply your Sequelize schema to the database.
+2. **Automatic migration planning** - use `atlas migrate diff --env sequelize` to automatically plan a migration from  
+  the current database version to the Sequelize schema.
+
+### Installation
+
+Install Atlas from macOS or Linux by running:
+```bash
+curl -sSf https://atlasgo.sh | sh
+```
+See [atlasgo.io](https://atlasgo.io/getting-started#installation) for more installation options.
+
+Install the provider by running:
+```bash
+npm i @ariga/ts-atlas-provider-sequelize
+```
+
+Make sure all your Node dependencies are installed by running:
+```bash
+npm i
+```
+
+#### Standalone 
+
+If all of your Sequelize models exist in a single Node module, 
+you can use the provider directly to load your Sequelize schema into Atlas.
+
+In your project directory, create a new file named `atlas.hcl` with the following contents:
+
+```hcl
+data "external_schema" "sequelize" {
+  program = [
+    "npx",
+    "@ariga/ts-atlas-provider-sequelize",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "mysql", // mariadb | postgres | sqlite | mssql
+  ]
+}
+
+env "sequelize" {
+  src = data.external_schema.sequelize.url
+  dev = "docker://mysql/8/dev"
+  migration {
+    dir = "file://migrations"
+  }
+  format {
+    migrate {
+      diff = "{{ sql . \"  \" }}"
+    }
+  }
+}
+```
+
+#### As TS Script 
+
+If you want to use the provider as TS script, you can use the provider as follows:
+
+Create a new file named `load.ts` with the following contents:
+
+```ts
+#!/usr/bin/env ts-node-script
+
+// import sequelize models you want to load
+import User from "./models/user";
+import Task from "./models/task";
+import { loadModels } from "@ariga/ts-atlas-provider-sequelize/src/sequelize_schema";
+
+console.log(loadModels("mysql", [User, Task]));
+```
+
+Next, in your project directory, create a new file named `atlas.hcl` with the following contents:
+
+```hcl
+data "external_schema" "sequelize" {
+    program = [
+        "npx",
+        "ts-node",
+        "load.ts",
+        "mysql"
+    ]
+}
+
+env "sequelize" {
+    src = data.external_schema.sequelize.url
+    dev = "docker://mysql/8/dev"
+    migration {
+        dir = "file://migrations"
+    }
+    format {
+        migrate {
+            diff = "{{ sql . \"  \" }}"
+        }
+    }
+}
+```
+
+### Usage
+
+Once you have the provider installed, you can use it to apply your Sequelize schema to the database:
+
+#### Apply
+
+You can use the `atlas schema apply` command to plan and apply a migration of your database to
+your current Sequelize schema. This works by inspecting the target database and comparing it to the
+Sequelize schema and creating a migration plan. Atlas will prompt you to confirm the migration plan
+before applying it to the database.
+
+```bash
+atlas schema apply --env sequelize -u "mysql://root:password@localhost:3306/mydb"
+```
+Where the `-u` flag accepts the [URL](https://atlasgo.io/concepts/url) to the
+target database.
+
+#### Diff
+
+Atlas supports a [version migration](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) 
+workflow, where each change to the database is versioned and recorded in a migration file. You can use the
+`atlas migrate diff` command to automatically generate a migration file that will migrate the database
+from its latest revision to the current Sequelize schema.
+
+```bash
+atlas migrate diff --env sequelize 
+````
+
+### Supported Databases
+
+The provider supports the following databases:
+* MySQL
+* MariaDB
+* PostgreSQL
+* SQLite
+* Microsoft SQL Server
+### Issues
+
+Please report any issues or feature requests in the [ariga/atlas](https://github.com/ariga/atlas/issues) repository.
+
+### License
+
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ariga/ts-atlas-provider-sequelize",
   "version": "0.0.0",
-  "description": "",
+  "description": "Load Sequelize-TypeScript models into an Atlas project.",
+  "homepage": "https://github.com/ariga/atlas-provider-sequelize",
   "bin": "src/index.ts",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
there are 3 README files, 1 for the root project, 1 for JavaScript and 1 for Typescript.
They are all pretty similar to each other.
The reason I did it this way is in order to have README in the `npm` page of the the JS and TS providers, and also have README in the root of the repo in GitHub