### PR TITLE
Changes behaviour of ts provider to behave like js provider

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -35,9 +35,14 @@ y.command(
         return;
       }
       const absolutePath = path.resolve(argv.path);
+      const files = fs.readdirSync(absolutePath);
+      const models: string[] = [];
+      files.forEach((file) => {
+        if (file !== "index.ts") models.push(absolutePath + "/" + file);
+      })
       const sequelize = new Sequelize({
         dialect: argv.dialect,
-        models: [absolutePath + "/*.ts"],
+        models: models,
       } as SequelizeOptions);
       console.log(loadSQL(sequelize, argv.dialect));
     } catch (e) {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -38,7 +38,7 @@ y.command(
       const files = fs.readdirSync(absolutePath);
       const models: string[] = [];
       files.forEach((file) => {
-        if (file !== "index.ts") models.push(absolutePath + "/" + file);
+        if (file !== "index.ts" && file.includes(".ts")) models.push(absolutePath + "/" + file);
       })
       const sequelize = new Sequelize({
         dialect: argv.dialect,


### PR DESCRIPTION
This is a relatively small PR however it is a reasonable QoL change. When using the `ts` variant provider the path provided is not filtered to remove a possible `index.ts` file which is a very common occurrence. With the proposed changes the provider will now read the directory and filter out all files that are not `.ts` files and not and `index.ts` file.